### PR TITLE
Add dollar output

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -63,7 +63,7 @@ pub enum FeesSubCommands {
         #[arg(long, value_name = "DESTINATION_BLOCK_NUMBER")]
         destination_block_number: Option<u32>,
         /// Allows the output to display the dollar cost estimation
-        #[arg(long, value_name = "USD", default_value = "false")]
+        #[arg(long, value_name = "BOOL", default_value = "false")]
         usd: Option<bool>,
     },
     /// Output a recap of used resources

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -62,6 +62,9 @@ pub enum FeesSubCommands {
         /// If not provided, the default is the latest block.
         #[arg(long, value_name = "DESTINATION_BLOCK_NUMBER")]
         destination_block_number: Option<u32>,
+        /// Allows the output to display the dollar cost estimation
+        #[arg(long, value_name = "USD", default_value = "false")]
+        usd: Option<bool>,
     },
     /// Output a recap of used resources
     // TODO: Ideally find a way to have either `tx_hash || transaction_file` as mandatory args

--- a/src/currencies.rs
+++ b/src/currencies.rs
@@ -1,0 +1,41 @@
+use ethers::types::U256;
+
+const URL: &'static str =
+    "https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd";
+
+fn get_eth_price() -> Option<f32> {
+    let body = reqwest::blocking::get(URL).ok()?.text().ok()?;
+
+    let parsed = json::parse(&body).ok()?;
+    let num = parsed["ethereum"]["usd"].as_f32()?;
+
+    Some(num)
+}
+
+/// Returns the string corresponding to the dollar cost in dollars (USD).
+/// The oracle is coingecko (see [`URL`]).
+/// Output is formatted with a precision of 4
+pub fn format_dollar_cost(fee: U256) -> String {
+    let eth_price = get_eth_price();
+    let eth_price = match eth_price {
+        None => return String::from("could not display USD estimate: failed to get eth price"),
+        Some(p) => p,
+    };
+
+    let fee_in_eth = ethers::utils::format_units(fee, "ether");
+    let fee_in_eth = match fee_in_eth {
+        Err(_) => return String::from("could not display USD estimate: failed to convert fees"),
+        Ok(fee) => fee,
+    };
+
+    let float = fee_in_eth.parse::<f32>();
+    let float = match float {
+        Err(_) => {
+            return String::from("could not display USD estimate: failed to parse the number")
+        }
+        Ok(f) => f,
+    };
+
+    let dollar_fee = float * eth_price;
+    format!("${:.4} USD", dollar_fee)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@
 //! --destination-block-number 15925
 //! ```
 pub mod cli;
+pub mod currencies;
 pub mod model;
 pub mod resources;
 use ethers::{types::U256, utils};
@@ -86,6 +87,7 @@ pub fn estimate_cost_on_network(
     destination_network_gateway_url: &str,
     source_block_number: &Option<u32>,
     destination_block_number: &Option<u32>,
+    usd: &Option<bool>,
 ) -> Result<String> {
     let source_block_number = match source_block_number {
         Some(block_number) => block_number.to_string(),
@@ -118,9 +120,14 @@ pub fn estimate_cost_on_network(
         "transaction actual fee on destination network: {}",
         destination_tx_actual_fee
     );
-    let destination_tx_actual_fee_in_eth = utils::format_units(destination_tx_actual_fee, "ether")?;
-
-    Ok(destination_tx_actual_fee_in_eth)
+    let output = utils::format_units(destination_tx_actual_fee, "ether")?;
+    match usd {
+        None | Some(false) => Ok(format!("{output} ETH")),
+        Some(true) => Ok(format!(
+            "{output} ETH ({})",
+            &crate::currencies::format_dollar_cost(destination_tx_actual_fee)
+        )),
+    }
 }
 
 /// Query a transaction from a network.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,12 +18,14 @@
 //! let destination_network_gateway_url = "https://alpha-mainnet.starknet.io/feeder_gateway";
 //! let source_block_number = Some(21410);
 //! let destination_block_number = Some(15925);
+//! let usd = Some(true);
 //! let fees = estimate_cost_on_network(
 //!   tx_hash,
 //!   &source_network_gateway_url,
 //!   &destination_network_gateway_url,
 //!   &source_block_number,
-//!   &destination_block_number
+//!   &destination_block_number,
+//!   &usd
 //! ).unwrap();
 //! println!("{}", fees);
 //! ```
@@ -70,12 +72,14 @@ use model::{Block, Transaction, TransactionReceipt};
 /// let destination_network_gateway_url = "https://alpha-mainnet.starknet.io/feeder_gateway";
 /// let source_block_number = Some(21410);
 /// let destination_block_number = Some(15925);
+/// let usd = Some(true);
 /// let fees = estimate_cost_on_network(
 ///   tx_hash,
 ///   &source_network_gateway_url,
 ///   &destination_network_gateway_url,
 ///   &source_block_number,
-///   &destination_block_number
+///   &destination_block_number,
+///   &usd
 /// ).unwrap();
 /// println!("{}", fees);
 /// ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ fn main() -> Result<()> {
                 destination_network_gateway_url,
                 source_block_number,
                 destination_block_number,
+                usd,
             } => {
                 let actual_fees_on_destination_network = estimate_cost_on_network(
                     tx_hash,
@@ -26,8 +27,9 @@ fn main() -> Result<()> {
                     destination_network_gateway_url,
                     source_block_number,
                     destination_block_number,
+                    usd,
                 )?;
-                println!("{} ETH", actual_fees_on_destination_network);
+                println!("{}", actual_fees_on_destination_network);
             }
             FeesSubCommands::Summary {
                 tx_hash,


### PR DESCRIPTION
Adds the `--usd true|false` option, which allows the user to get an USD output of his fee estimation.

the output now looks like this:
```
> howmuch-rs fees estimate-on-network --tx-hash=0x073251e7ff3843c4954aa2e7f38d8c29034e34a1ddbaeb1e62605ec10ca22367 \
  --source-block-number=21410 \
  --destination-block-number=15925 \
  --usd true`
0.000485046227677767 ETH ($0.6158 USD)
```

Closes #2 